### PR TITLE
chmod the token_file after creation

### DIFF
--- a/boxapi.c
+++ b/boxapi.c
@@ -97,6 +97,7 @@ void save_tokens(const char * token_file)
 	if(tf) {
 		fprintf(tf, "%s\n%s\n", auth_token, refresh_token);
 		fclose(tf);
+		chmod(token_file, S_IRUSR);
 	}
 }
  


### PR DESCRIPTION
Set the permissions of the token file to 0400 so that only the owner can read the tokens.
Otherwise, any other system user could assume a default ~/.boxfs/ path and read in the user's tokens, thereby gaining access to that user's Box files and possibly account.
