### PR TITLE
Pass options to libfuse with -o parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The first mount can be quite slow because boxfs will fetch and cache info
 	  -G --gid                    group id to use for group permissions
 	  -F --fperm                  file permissions (default 0644)
 	  -D --dperm                  directory permissions (default 0755)
+	  -o --fuse_options           specify FUSE mount options
 
 
 When you've done using your files, unmount your filsystem

--- a/boxfs-init
+++ b/boxfs-init
@@ -47,6 +47,7 @@ expire_time = 1440
 #gid = 1000
 fperm = 644
 dperm = 755
+#fuse_options = allow_other,default_permissions
 
 " >$BOXDIR/$CONF
 

--- a/boxfs.c
+++ b/boxfs.c
@@ -223,9 +223,17 @@ static struct fuse_operations box_oper = {
 int main(int argc, char *argv[])
 {
     int fuse_res;
+    struct fuse_args args = FUSE_ARGS_INIT(argc, argv);
 
     if(api_init(&argc, &argv)) return 1;
-    fuse_res = fuse_main(argc, argv, &box_oper, NULL);
+
+    char *fuse_options = argv[2];
+    if (fuse_options) {
+        fuse_opt_parse(&args, NULL, NULL, NULL);
+        fuse_opt_add_arg(&args, fuse_options);
+    }
+
+    fuse_res = fuse_main(args.argc, args.argv, &box_oper, NULL);
     api_free(argc, argv);
      
     return fuse_res;   

--- a/boxopts.c
+++ b/boxopts.c
@@ -99,7 +99,8 @@ void show_help()
             "  -U --uid                    user id to use as file owner (defaults to you)\n"
             "  -G --gid                    group id to use for group permissions\n"
             "  -F --fperm                  file permissions (default 0644)\n"
-            "  -D --dperm                  directory permissions (default 0755)\n\n"
+            "  -D --dperm                  directory permissions (default 0755)\n"
+            "  -o --fuse_options           specify FUSE mount options\n\n"
             "Configuration file example:\n"
             "mountpoint = /path/to/folder\n"
             "verbose    = no\n"
@@ -110,7 +111,8 @@ void show_help()
             "uid = 1000\n"
             "gid = 100\n"
             "fperm = 644\n"
-            "dperm = 755\n\n");
+            "dperm = 755\n"
+            "fuse_options = allow_other,default_permissions\n\n");
             
             exit(0);
 }
@@ -132,6 +134,7 @@ int parse_options (int* argc, char*** argv, box_options * options)
                 {'G', "gid", OPT_INT, &options->gid},
                 {'F', "fperm", OPT_INT, &options->fperm},
                 {'D', "dperm", OPT_INT, &options->dperm},
+                {'o', "fuse_options", OPT_STRING, &options->fuse_options},
                 {'h', NULL, OPT_CALLBACK, &show_help},
 		{0, "mountpoint", OPT_STRING, &options->mountpoint}
 	};
@@ -190,7 +193,20 @@ int parse_options (int* argc, char*** argv, box_options * options)
 				*argc-=1;
 			}
 		}
+
+		/* prefix the options with -o, such as "allow_other" to "-oallow_other"
+		   since that is how `fuse_opt_add_arg` works in libfuse */
+		if(options->fuse_options) {
+		    char * fuse_option_prefix = "-o";
+		    size_t fuse_options_length = strlen(fuse_option_prefix) + strlen(options->fuse_options) + 1;
+		    char * tmp_fuse_options = (char *) malloc(fuse_options_length);
+		    strcpy(tmp_fuse_options, fuse_option_prefix);
+		    strcat(tmp_fuse_options, options->fuse_options);
+		    options->fuse_options = tmp_fuse_options;
+		}
+
 		args[1] = options->mountpoint;
+		args[2] = options->fuse_options;
 
 		/* check for fuse options and build the new argv for fuse main */
 		if(*argc) {
@@ -199,6 +215,7 @@ int parse_options (int* argc, char*** argv, box_options * options)
 		        
 			fargs[0] = args[0]; // "boxfs"
 			fargs[1] = args[1]; // mountpoint
+			fargs[2] = args[2]; // fuse_options
 
 		        for(i = 1; i < *argc; ++i) fargs[i+1] = (*argv)[i];
 

--- a/boxopts.h
+++ b/boxopts.h
@@ -22,6 +22,7 @@ typedef struct box_options_t
     int	verbose;
     int splitfiles;
     int expire_time;
+    char* fuse_options;
 } box_options;
 
 extern box_options options;


### PR DESCRIPTION
Closes #22.

Now I can do:
```
$ boxfs -o allow_other ~/box
```
:D

Multiple options can be passed separated by a comma like:
```
$ boxfs -o allow_other,default_permissions ~/box
```